### PR TITLE
format l1_gas_price & l1_fee display

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -437,7 +437,7 @@
                 text: gettext("L1 Fee") %>
               <%= gettext "L1 Fee" %>
             </dt>
-            <dd class="col-sm-9 col-lg-10"> <%= l1_fee(@transaction) %> </dd>
+            <dd class="col-sm-9 col-lg-10"> <%= l1_fee(@transaction, :ether) %> </dd>
           </dl>
           <!-- L1 Fee Scalar-->
           <dl class="row">

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -406,7 +406,7 @@ defmodule BlockScoutWeb.TransactionView do
   def l1_gas_price(%Transaction{l1_gas_price: nil}, _unit), do: gettext("Pending")
 
   def l1_gas_price(%Transaction{l1_gas_price: l1_gas_price}, unit) when unit in ~w(wei gwei ether)a do
-    l1_gas_price
+    format_wei_value(l1_gas_price, unit)
   end
 
   def l1_fee(%Transaction{l1_fee: nil}), do: gettext("Pending")

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -409,10 +409,10 @@ defmodule BlockScoutWeb.TransactionView do
     format_wei_value(l1_gas_price, unit)
   end
 
-  def l1_fee(%Transaction{l1_fee: nil}), do: gettext("Pending")
+  def l1_fee(%Transaction{l1_fee: nil}, _unit), do: gettext("Pending")
 
-  def l1_fee(%Transaction{l1_fee: l1_fee}) do
-    l1_fee
+  def l1_fee(%Transaction{l1_fee: l1_fee}, unit) when unit in ~w(wei gwei ether)a do
+    format_wei_value(l1_fee, unit)
   end
 
   def l1_gas_used(%Transaction{l1_gas_used: nil}), do: gettext("Pending")

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -165,7 +165,7 @@ defmodule Explorer.Chain.Transaction do
           value: Wei.t(),
           revert_reason: String.t() | nil,
           has_error_in_internal_txs: boolean(),
-          l1_gas_price: Gas.t() | nil,
+          l1_gas_price: wei_per_gas,
           l1_gas_used: Gas.t() | nil,
           l1_fee: Gas.t() | nil,
           l1_fee_scalar: Gas.t() | nil,
@@ -242,7 +242,7 @@ defmodule Explorer.Chain.Transaction do
     field(:value, Wei)
     field(:revert_reason, :string)
     field(:has_error_in_internal_txs, :boolean)
-    field(:l1_gas_price, :decimal)
+    field(:l1_gas_price, Wei)
     field(:l1_gas_used, :decimal)
     field(:l1_fee, :decimal)
     field(:l1_fee_scalar, :decimal)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -167,7 +167,7 @@ defmodule Explorer.Chain.Transaction do
           has_error_in_internal_txs: boolean(),
           l1_gas_price: wei_per_gas,
           l1_gas_used: Gas.t() | nil,
-          l1_fee: Gas.t() | nil,
+          l1_fee: wei_per_gas,
           l1_fee_scalar: Gas.t() | nil,
           l1_origin_tx_hash: Hash.t() | nil
         }
@@ -244,7 +244,7 @@ defmodule Explorer.Chain.Transaction do
     field(:has_error_in_internal_txs, :boolean)
     field(:l1_gas_price, Wei)
     field(:l1_gas_used, :decimal)
-    field(:l1_fee, :decimal)
+    field(:l1_fee, Wei)
     field(:l1_fee_scalar, :decimal)
     field(:l1_origin_tx_hash, :string)
 


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
