### PR TITLE
feat: add axelar custom proxy standard with input and delegatecall check

### DIFF
--- a/apps/block_scout_web/assets/js/pages/verification_form.js
+++ b/apps/block_scout_web/assets/js/pages/verification_form.js
@@ -28,7 +28,6 @@ export function reducer (state = initialState, action) {
       if (action.msg.verificationResult === 'ok') {
         return window.location.replace(window.location.href.split('/contract_verifications')[0].split('/verify')[0] + '/contracts')
       } else {
-        console.log('received verification result',  action.msg.verificationResult)
         return Object.assign({}, state, {
           newForm: action.msg.verificationResult
         })

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5109,6 +5109,109 @@ defmodule Explorer.Chain do
     end
   end
 
+  def fetch_latest_delegate_call_txn(address_hash) do
+    query = from(
+      txn in Transaction,
+      where: txn.to_address_hash == ^address_hash or txn.created_contract_address_hash == ^address_hash,
+      where: txn.status == ^1,
+      order_by: [desc: txn.block_number],
+      limit: 10
+    )
+    results = Repo.all(query)
+
+
+    fetch_internal_transaction_for_delegate_call(results)
+  end
+
+  def fetch_internal_transaction_for_delegate_call(list) do
+
+    result = Enum.reduce_while(list, nil, fn %{hash: hash} , _acc ->
+      txn_hash_string = Hash.to_string(hash)
+      trace_url = Application.get_env(:explorer, :json_rpc_named_arguments)[:transport_options][:method_to_url][:debug_traceTransaction]
+      rpc_url = trace_url = Application.get_env(:explorer, :json_rpc_named_arguments)[:transport_options][:url]
+      post_url = case trace_url do
+        nil ->
+          rpc_url
+        _ ->
+          trace_url
+      end
+
+      timeout =  System.get_env("ETHEREUM_JSONRPC_DEBUG_TRACE_TRANSACTION_TIMEOUT", "30s")
+      payload = %{
+        jsonrpc: "2.0",
+        method: "debug_traceTransaction",
+        params: [
+          txn_hash_string,
+          %{
+            tracer: "callTracer",
+            timeout: timeout
+          }
+        ],
+        id: 0
+      }
+      headers = ["Content-Type": "application/json"]
+
+      if is_nil(post_url) do
+        {:halt, nil}
+      end
+
+      case HTTPoison.post(post_url, Jason.encode!(payload), headers, []) do
+        {:ok, %HTTPoison.Response{body: body, status_code: status_code}} ->
+
+          %{"result" => result} = Jason.decode!(body)
+
+          search_delegate_call = delegate_call_list(result)
+
+          if !Enum.empty?(search_delegate_call) do
+            final_delegate_call = List.last(search_delegate_call)
+            {:halt, final_delegate_call}
+          else
+            {:cont, nil}
+          end
+
+        {:error, %HTTPoison.Error{reason: reason}} ->
+
+          {:halt, nil}
+      end
+
+    end)
+
+    result
+  end
+
+  def delegate_call_list(data) do
+    delegate_call_list(data, [])
+  end
+
+  defp delegate_call_list(data, res) when is_map(data) do
+    case data["type"] do
+      "DELEGATECALL" ->
+        updated_res = res ++ [
+          %{
+            from: data["from"],
+            to: data["to"],
+            type: data["type"]
+          }
+        ]
+        if is_list(data["calls"]) do
+          Enum.reduce(data["calls"], res, fn item, acc ->
+            delegate_call_list(item, updated_res)
+          end)
+        else
+          updated_res
+        end
+      _ ->
+        if is_list(data["calls"]) do
+          Enum.reduce(data["calls"], res, fn item, acc ->
+            delegate_call_list(item, acc)
+          end)
+        else
+          res
+        end
+
+    end
+  end
+
   def smart_contract_verified?(address_hash) do
     check_verified(address_hash)
   end
@@ -6861,6 +6964,28 @@ defmodule Explorer.Chain do
     inputs
     |> Enum.find(fn input ->
       Map.get(input, "name") == "_masterCopy"
+    end)
+  end
+
+
+  def gateway_implementation_pattern?(method) do
+    Map.get(method, "type") == "constructor" &&
+      method
+      |> Enum.find(fn item ->
+        case item do
+          {"inputs", inputs} ->
+            gateway_implementation_input?(inputs)
+
+          _ ->
+            false
+        end
+      end)
+  end
+
+  defp gateway_implementation_input?(inputs) do
+    inputs
+    |> Enum.find(fn input ->
+      Map.get(input, "name") == "gatewayImplementation"
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5109,6 +5109,7 @@ defmodule Explorer.Chain do
     end
   end
 
+  # query an address last 10 success txn and pass result to fetch_internal_transaction_for_delegate_call
   def fetch_latest_delegate_call_txn(address_hash) do
     query = from(
       txn in Transaction,
@@ -5123,6 +5124,7 @@ defmodule Explorer.Chain do
     fetch_internal_transaction_for_delegate_call(results)
   end
 
+  # fetch internal transaction on rpc to check whether this transaction include a delegatecall, if found, return latest delegatecall "to" address, if not return nil
   def fetch_internal_transaction_for_delegate_call(list) do
 
     result = Enum.reduce_while(list, nil, fn %{hash: hash} , _acc ->
@@ -6967,7 +6969,7 @@ defmodule Explorer.Chain do
     end)
   end
 
-
+ # check if smart contract is gateway_implementation standard
   def gateway_implementation_pattern?(method) do
     Map.get(method, "type") == "constructor" &&
       method

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -527,7 +527,7 @@ defmodule Explorer.Chain.SmartContract do
       abi
       |> Enum.find(fn method ->
         Map.get(method, "name") == "implementation" ||
-          Chain.master_copy_pattern?(method)
+        Chain.master_copy_pattern?(method) || Chain.gateway_implementation_pattern?(method)
       end)
 
     if implementation_method_abi ||
@@ -673,6 +673,12 @@ defmodule Explorer.Chain.SmartContract do
         Chain.master_copy_pattern?(method)
       end)
 
+    gateway_implementation_input_abi =
+      abi
+      |> Enum.find(fn method ->
+        Chain.gateway_implementation_pattern?(method)
+      end)
+
     implementation_address =
       cond do
         implementation_method_abi ->
@@ -683,6 +689,36 @@ defmodule Explorer.Chain.SmartContract do
 
         master_copy_method_abi ->
           get_implementation_address_hash_from_master_copy_pattern(proxy_address_hash)
+
+        gateway_implementation_input_abi ->
+            constructor_abi = Enum.find(abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)
+            input_types = Enum.map(constructor_abi["inputs"], &ABI.FunctionSelector.parse_specification_type/1)
+            smart_contract =  Chain.address_hash_to_smart_contract_without_twin(proxy_address_hash,[])
+
+            delegate = Chain.fetch_latest_delegate_call_txn(proxy_address_hash)
+
+            if is_nil(smart_contract) do
+              @burn_address_hash_str
+            else
+              if is_nil(delegate) do
+
+                if smart_contract.constructor_arguments do
+                  {val,result} =
+                    smart_contract.constructor_arguments
+                    |> BlockScoutWeb.AddressContractView.decode_data(input_types)
+                    |> Enum.zip(constructor_abi["inputs"])
+                    |> Enum.find(fn {val, %{"type" => type}} ->
+                      type == "address"
+                    end)
+                  address_hash = "0x" <> Base.encode16(val, case: :lower)
+                else
+                  @burn_address_hash_str
+                end
+
+              else
+                delegate.to
+              end
+            end
 
         true ->
           get_implementation_address_hash_eip_1967(proxy_address_hash)

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -690,6 +690,7 @@ defmodule Explorer.Chain.SmartContract do
         master_copy_method_abi ->
           get_implementation_address_hash_from_master_copy_pattern(proxy_address_hash)
 
+        # check if smart contract have any delegatecall, if not use the contructor gatewayImplementation input as implementation
         gateway_implementation_input_abi ->
             constructor_abi = Enum.find(abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)
             input_types = Enum.map(constructor_abi["inputs"], &ABI.FunctionSelector.parse_specification_type/1)


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
